### PR TITLE
Support mTLS domainmappings

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -152,7 +152,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 			originSecret = secret
 		}
 
-		certificateHash, err := resources.CalculateCertificateHash(originSecret)
+		certificateHash, err := resources.CalculateCertificateHash(ctx, originSecret)
 		if err != nil {
 			return err
 		}
@@ -206,7 +206,11 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 
 				if len(allGatewaysByCertificateHash) == 0 {
 					// create the Gateway
-					dmGateway, err := resources.MakeGateway(ctx, r.svcLister, certificateHash, ing)
+					mode, err := getTlsMode(ing, originSecret)
+					if err != nil {
+						return err
+					}
+					dmGateway, err := resources.MakeGateway(ctx, r.svcLister, certificateHash, ing, mode)
 					if err != nil {
 						return err
 					}
@@ -256,7 +260,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 						return err
 					}
 
-					canBeUpdated, err := resources.AreAllKIngressesReferencingCertificate(r.ingressLister, r.secretLister, allGatewaysByHost[0], certificateHash)
+					canBeUpdated, err := resources.AreAllKIngressesReferencingCertificate(ctx, r.ingressLister, r.secretLister, allGatewaysByHost[0], certificateHash)
 					if err != nil {
 						return err
 					}
@@ -283,7 +287,11 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 					} else {
 						if len(allGatewaysByCertificateHash) == 0 {
 							// create the Gateway
-							dmGateway, err := resources.MakeGateway(ctx, r.svcLister, certificateHash, ing)
+							mode, err := getTlsMode(ing, originSecret)
+							if err != nil {
+								return err
+							}
+							dmGateway, err := resources.MakeGateway(ctx, r.svcLister, certificateHash, ing, mode)
 							if err != nil {
 								return err
 							}

--- a/pkg/reconciler/ingress/ingress_ce.go
+++ b/pkg/reconciler/ingress/ingress_ce.go
@@ -2,11 +2,13 @@ package ingress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	istiov1beta1 "istio.io/api/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,10 +16,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"knative.dev/net-istio/pkg/reconciler/ingress/resources"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	knnetapi "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	knnetlisters "knative.dev/networking/pkg/client/listers/networking/v1alpha1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
+)
+
+const (
+	annotationTlsMode = "codeengine.cloud.ibm.com/tls-mode"
+	tlsModeMutual     = "mutual"
 )
 
 // FindKIngresses looks for all KIngresses that are owned by a DomainMapping and reference a TLS Secret in the same namespace
@@ -130,4 +139,30 @@ func lockCertificate(ctx context.Context, client kubernetes.Interface, certifica
 
 func isUnableToAcquireLock(err error) bool {
 	return strings.HasPrefix(err.Error(), "unable to acquire lock")
+}
+
+func containsCaCrt(secret *corev1.Secret) bool {
+	_, found := secret.Data[resources.CaSecretKey]
+	return found
+}
+
+// TODO: remove looking this up on the secret once UX support is there
+func getTlsMode(ing *v1alpha1.Ingress, secret *corev1.Secret) (istiov1beta1.ServerTLSSettings_TLSmode, error) {
+	mode, found := ing.Annotations[annotationTlsMode]
+	if found && strings.ToLower(mode) == tlsModeMutual { // only mutual supported
+		var err error
+		if !containsCaCrt(secret) {
+			err = errors.New("secret contains no ca bundle")
+		}
+		return istiov1beta1.ServerTLSSettings_MUTUAL, err
+	}
+	mode, found = secret.Annotations[annotationTlsMode]
+	if found && strings.ToLower(mode) == tlsModeMutual { // only mutual supported
+		var err error
+		if !containsCaCrt(secret) {
+			err = errors.New("secret contains no ca bundle")
+		}
+		return istiov1beta1.ServerTLSSettings_MUTUAL, err
+	}
+	return istiov1beta1.ServerTLSSettings_SIMPLE, nil
 }

--- a/pkg/reconciler/ingress/ingress_ce_test.go
+++ b/pkg/reconciler/ingress/ingress_ce_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"testing"
 
+	"istio.io/api/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +98,85 @@ func TestFindKIngresses(t *testing.T) {
 
 	if returnedIngress[0].ObjectMeta.Name != "ingress1" {
 		t.Errorf("wrong ingress returned %v", returnedIngress)
+		return
+	}
+}
+
+func TestGetTlsModeIngress(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "abc",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{"ca.crt": {}},
+	}
+	ingress := &knnetapi.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ingress1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationTlsMode: tlsModeMutual,
+			},
+		},
+	}
+	mode, err := getTlsMode(ingress, secret)
+	if err != nil {
+		t.Error("unexpected error", err)
+		return
+	}
+	if mode != v1alpha3.ServerTLSSettings_MUTUAL {
+		t.Errorf("wrong TLS mode returned %v", mode)
+		return
+	}
+}
+
+func TestGetTlsModeSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationTlsMode: tlsModeMutual,
+			},
+		},
+		Data: map[string][]byte{"ca.crt": {}},
+	}
+	ingress := &knnetapi.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ingress1",
+			Namespace: "default",
+		},
+	}
+	mode, err := getTlsMode(ingress, secret)
+	if err != nil {
+		t.Error("unexpected error", err)
+		return
+	}
+	if mode != v1alpha3.ServerTLSSettings_MUTUAL {
+		t.Errorf("wrong TLS mode returned %v", mode)
+		return
+	}
+}
+
+func TestGetTlsModeNoCA(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationTlsMode: tlsModeMutual,
+			},
+		},
+	}
+	ingress := &knnetapi.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ingress1",
+			Namespace: "default",
+		},
+	}
+	_, err := getTlsMode(ingress, secret)
+	if err == nil {
+		t.Error("expected error, got none")
 		return
 	}
 }

--- a/pkg/reconciler/ingress/resources/gateway_ce.go
+++ b/pkg/reconciler/ingress/resources/gateway_ce.go
@@ -141,7 +141,7 @@ func EnsureGatewayCoversKIngress(gateway *istioclient.Gateway, kingress *knnetap
 }
 
 // MakeGateway creates a Gateway object for a certificate hash and KIngress
-func MakeGateway(ctx context.Context, svcLister corev1listers.ServiceLister, certificateHash string, kingress *knnetapi.Ingress) (*istioclient.Gateway, error) {
+func MakeGateway(ctx context.Context, svcLister corev1listers.ServiceLister, certificateHash string, kingress *knnetapi.Ingress, tlsMode istioapi.ServerTLSSettings_TLSmode) (*istioclient.Gateway, error) {
 	gatewayServices, err := getGatewayServices(ctx, kingress, svcLister)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func MakeGateway(ctx context.Context, svcLister corev1listers.ServiceLister, cer
 					Protocol: "HTTPS",
 				},
 				Tls: &istioapi.ServerTLSSettings{
-					Mode:           istioapi.ServerTLSSettings_SIMPLE,
+					Mode:           tlsMode,
 					CredentialName: certificateHash,
 				},
 			}, {
@@ -315,7 +315,7 @@ func extractSourceKIngresses(gateway *istioclient.Gateway) ([]namespacedName, er
 }
 
 // AreAllKIngressesReferencingCertificate checks if the KIngresses that are using a Gateway are all pointing to a Secret with a common certificateHash
-func AreAllKIngressesReferencingCertificate(ingressLister knnetlisters.IngressLister, secretLister corev1listers.SecretLister, gateway *istioclient.Gateway, certificateHash string) (bool, error) {
+func AreAllKIngressesReferencingCertificate(ctx context.Context, ingressLister knnetlisters.IngressLister, secretLister corev1listers.SecretLister, gateway *istioclient.Gateway, certificateHash string) (bool, error) {
 	kingressesNamespacedNames, err := extractSourceKIngresses(gateway)
 	if err != nil {
 		return false, err
@@ -337,7 +337,7 @@ func AreAllKIngressesReferencingCertificate(ingressLister knnetlisters.IngressLi
 			return false, err
 		}
 
-		secretCertificateHash, err := CalculateCertificateHash(secret)
+		secretCertificateHash, err := CalculateCertificateHash(ctx, secret)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/reconciler/ingress/resources/gateway_ce_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_ce_test.go
@@ -290,7 +290,7 @@ func TestMakeGateway(t *testing.T) {
 
 	certificateHash := "2152137217362176376"
 
-	returnedGateway, err := MakeGateway(ctx, serviceLister, certificateHash, kingress)
+	returnedGateway, err := MakeGateway(ctx, serviceLister, certificateHash, kingress, istioapi.ServerTLSSettings_SIMPLE)
 
 	if err != nil {
 		t.Error("Got error", err)
@@ -328,6 +328,104 @@ func TestMakeGateway(t *testing.T) {
 				},
 				Tls: &istioapi.ServerTLSSettings{
 					Mode:           istioapi.ServerTLSSettings_SIMPLE,
+					CredentialName: certificateHash,
+				},
+			}, {
+				Hosts: []string{
+					"abc",
+				},
+				Port: &istioapi.Port{
+					Name:     "http",
+					Number:   80,
+					Protocol: "HTTP",
+				},
+				Tls: &istioapi.ServerTLSSettings{
+					HttpsRedirect: true,
+				},
+			}},
+		},
+	}
+
+	if diff := cmp.Diff(expectedGateway, returnedGateway, defaultGatewayCmpOpts); diff != "" {
+		t.Error("Unexpected Gateway (-want, +got):", diff)
+	}
+}
+
+func TestMakeMutualGateway(t *testing.T) {
+	serviceLister := &fakeServiceLister{
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: config.IstioNamespace,
+				Name:      "gateway",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"gwt": "istio",
+				},
+			},
+		}},
+	}
+
+	kingress := &knnetapi.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "customer-namespace",
+			Name:      "abc",
+			Annotations: map[string]string{
+				"codeengine.cloud.ibm.com/tls-mode": "mutual",
+			},
+		},
+	}
+
+	ctx := config.ToContext(context.Background(), &config.Config{
+		Istio: &config.Istio{
+			IngressGateways: []config.Gateway{{
+				Name:       "gateway",
+				Namespace:  config.IstioNamespace,
+				ServiceURL: "gateway.istio-system.svc.cluster.local",
+			}},
+		},
+	})
+
+	certificateHash := "2152137217362176123"
+
+	returnedGateway, err := MakeGateway(ctx, serviceLister, certificateHash, kingress, istioapi.ServerTLSSettings_MUTUAL)
+
+	if err != nil {
+		t.Error("Got error", err)
+		return
+	}
+
+	expectedGateway := &istioclient.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      returnedGateway.Name,
+			Namespace: config.IstioNamespace,
+			Annotations: map[string]string{
+				annotationKeyKIngresses: `[{"namespace":"customer-namespace","name":"abc"}]`,
+			},
+			Labels: map[string]string{
+				labelKeyDomainMappingGateway: labelValueDomainMappingGateway,
+				labelKeyCertificateHash:      certificateHash,
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GatewayGroupVersionKind.GroupVersion().String(),
+			Kind:       GatewayGroupVersionKind.Kind,
+		},
+		Spec: istioapi.Gateway{
+			Selector: map[string]string{
+				"gwt": "istio",
+			},
+			Servers: []*istioapi.Server{{
+				Hosts: []string{
+					"abc",
+				},
+				Port: &istioapi.Port{
+					Name:     "https",
+					Number:   443,
+					Protocol: "HTTPS",
+				},
+				Tls: &istioapi.ServerTLSSettings{
+					Mode:           istioapi.ServerTLSSettings_MUTUAL,
 					CredentialName: certificateHash,
 				},
 			}, {
@@ -617,7 +715,7 @@ func TestAreAllKIngressesReferencingCertificate(t *testing.T) {
 		secrets: []*corev1.Secret{secret1, secret2},
 	}
 
-	certificateHash, err := CalculateCertificateHash(secret1)
+	certificateHash, err := CalculateCertificateHash(context.Background(), secret1)
 	if err != nil {
 		t.Error("Got error", err)
 		return
@@ -675,7 +773,7 @@ func TestAreAllKIngressesReferencingCertificate(t *testing.T) {
 		},
 	}
 
-	are, err := AreAllKIngressesReferencingCertificate(ingressLister, secretLister, gateway, certificateHash)
+	are, err := AreAllKIngressesReferencingCertificate(context.Background(), ingressLister, secretLister, gateway, certificateHash)
 	if err != nil {
 		t.Error("Got error", err)
 		return
@@ -704,7 +802,7 @@ func TestAreAllKIngressesReferencingCertificate(t *testing.T) {
 		},
 	}
 
-	are, err = AreAllKIngressesReferencingCertificate(ingressLister, secretLister, gateway, certificateHash)
+	are, err = AreAllKIngressesReferencingCertificate(context.Background(), ingressLister, secretLister, gateway, certificateHash)
 	if err != nil {
 		t.Error("Got error", err)
 		return

--- a/pkg/reconciler/ingress/resources/secret_ce.go
+++ b/pkg/reconciler/ingress/resources/secret_ce.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -17,15 +16,20 @@ import (
 const (
 	labelKeyDomainMappingSecret   = "codeengine.cloud.ibm.com/domain-mapping-secret"
 	labelValueDomainMappingSecret = "true"
+	CaSecretKey                   = "ca.crt"
 )
 
 // CalculateCertificateHash creates the hash of the certificate of the TLS Secret
-func CalculateCertificateHash(secret *corev1.Secret) (string, error) {
-	certBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
-	if certBlock == nil {
-		return "", errors.New("failed to decode certificate")
+func CalculateCertificateHash(ctx context.Context, secret *corev1.Secret) (string, error) {
+	combinedCerts := decodeAndEncodePEMBlocks(ctx, secret.Name, secret.Namespace, secret.Data[corev1.TLSCertKey])
+
+	caCerts, found := secret.Data[CaSecretKey]
+	if found {
+		decodedCaCerts := decodeAndEncodePEMBlocks(ctx, secret.Name, secret.Namespace, caCerts)
+		combinedCerts = append(combinedCerts, decodedCaCerts...)
 	}
-	certSha224 := sha256.Sum224(certBlock.Bytes)
+
+	certSha224 := sha256.Sum224(combinedCerts)
 	var certFingerprint bytes.Buffer
 	for _, f := range certSha224 {
 		fmt.Fprintf(&certFingerprint, "%02x", f)
@@ -47,36 +51,43 @@ func MakeMirrorSecret(ctx context.Context, originSecret *corev1.Secret, certific
 	)
 }
 
-func correctSecretFormat(ctx context.Context, originSecret *corev1.Secret) *corev1.Secret {
-	var decodeAndEncodePEMBlocks = func(data []byte) (encodedData []byte) {
-		rest := data
-		for i := 0; len(strings.TrimSpace(string(rest))) > 0; i++ {
-			var pemBlock *pem.Block
-			pemBlock, rest = pem.Decode(rest)
+func decodeAndEncodePEMBlocks(ctx context.Context, name string, namespace string, data []byte) (encodedData []byte) {
+	rest := data
+	for i := 0; len(strings.TrimSpace(string(rest))) > 0; i++ {
+		var pemBlock *pem.Block
+		pemBlock, rest = pem.Decode(rest)
 
-			// In case the PEM decode fails to decode a block, the result will be nil. This should
-			// not happen, but if it does, we return the data as-is and log the incident.
-			if pemBlock == nil {
-				logging.FromContext(ctx).Errorf("failed to decode PEM block at index %d in secret %s/%s, returning secret data as-is", i, originSecret.Namespace, originSecret.Name)
-				return data
-			}
-
-			encodedBlock := pem.EncodeToMemory(pemBlock)
-			encodedData = append(encodedData, encodedBlock...)
+		// In case the PEM decode fails to decode a block, the result will be nil. This should
+		// not happen, but if it does, we return the data as-is and log the incident.
+		if pemBlock == nil {
+			logging.FromContext(ctx).Errorf("failed to decode PEM block at index %d in secret %s/%s, returning secret data as-is", i, namespace, name)
+			return data
 		}
 
-		return encodedData
+		encodedBlock := pem.EncodeToMemory(pemBlock)
+		encodedData = append(encodedData, encodedBlock...)
 	}
+
+	return encodedData
+}
+
+func correctSecretFormat(ctx context.Context, originSecret *corev1.Secret) *corev1.Secret {
 
 	certificateData := originSecret.Data[corev1.TLSCertKey]
 	privateKeyData := originSecret.Data[corev1.TLSPrivateKeyKey]
 
-	encodedCertificate := decodeAndEncodePEMBlocks(certificateData)
-	encodedPrivateKey := decodeAndEncodePEMBlocks(privateKeyData)
-
 	secret := originSecret.DeepCopy()
+
+	encodedCertificate := decodeAndEncodePEMBlocks(ctx, originSecret.Name, originSecret.Namespace, certificateData)
+	encodedPrivateKey := decodeAndEncodePEMBlocks(ctx, originSecret.Name, originSecret.Namespace, privateKeyData)
+
 	secret.Data[corev1.TLSCertKey] = encodedCertificate
 	secret.Data[corev1.TLSPrivateKeyKey] = encodedPrivateKey
+
+	caCertificateData, found := originSecret.Data[CaSecretKey]
+	if found {
+		secret.Data[CaSecretKey] = decodeAndEncodePEMBlocks(ctx, originSecret.Name, originSecret.Namespace, caCertificateData)
+	}
 
 	return secret
 }

--- a/vendor/knative.dev/networking/pkg/prober/prober.go
+++ b/vendor/knative.dev/networking/pkg/prober/prober.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -94,7 +95,7 @@ func ExpectsStatusCodes(statusCodes []int) Verifier {
 
 // Do sends a single probe to given target, e.g. `http://revision.default.svc.cluster.local:81`.
 // Do returns whether the probe was successful or not, or there was an error probing.
-func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...interface{}) (bool, error) {
+func Do(ctx context.Context, transport http.RoundTripper, target string, skipConnectError bool, ops ...interface{}) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		return false, fmt.Errorf("%s is not a valid URL: %w", target, err)
@@ -106,6 +107,10 @@ func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...
 	}
 
 	resp, err := transport.RoundTrip(req)
+	// accept required client certifcate as successful ingress configuration for domain mappings
+	if err != nil && strings.Contains(err.Error(), "tls: certificate required") && skipConnectError {
+		return true, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("error roundtripping %s: %w", target, err)
 	}
@@ -187,7 +192,7 @@ func (m *Manager) doAsync(ctx context.Context, target string, arg interface{}, p
 			inErr  error
 		)
 		err := wait.PollUntilContextTimeout(ctx, period, timeout, true, func(ctx context.Context) (bool, error) {
-			result, inErr = Do(ctx, m.transport, target, ops...)
+			result, inErr = Do(ctx, m.transport, target, false, ops...)
 			// Do not return error, which is from verifierError, as retry is expected until timeout.
 			return result, nil
 		})

--- a/vendor/knative.dev/networking/pkg/status/status.go
+++ b/vendor/knative.dev/networking/pkg/status/status.go
@@ -402,6 +402,7 @@ func (m *Prober) processWorkItem() bool {
 		ctx,
 		transport,
 		probeURL.String(),
+		isOwnedByDomainMapping(item),
 		prober.WithHeader(header.UserAgentKey, header.IngressReadinessUserAgent),
 		prober.WithHeader(header.ProbeKey, header.ProbeValue),
 		m.probeVerifier(item))
@@ -505,4 +506,16 @@ func deepCopy(in *url.URL) *url.URL {
 	// Safe to ignore the error since this is a deep copy
 	newURL, _ := url.Parse(in.String())
 	return newURL
+}
+
+func isOwnedByDomainMapping(item *workItem) bool {
+	if item == nil || item.ingressState == nil || item.ingressState.ing == nil {
+		return false
+	}
+	for _, owner := range item.ingressState.ing.OwnerReferences {
+		if owner.Kind == "DomainMapping" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- Support mTLS domainmappings
  - Only of type "MUTUAL"
  - Stop probing in case of TLS error and mark domainmapping as ready
  - Build certificate hash based on all certs + ca's
  - Configurable via annotation on domainmapping or secret of the domainmapping